### PR TITLE
adds uuid-dev for version 2

### DIFF
--- a/recipes/install_from_source.rb
+++ b/recipes/install_from_source.rb
@@ -24,6 +24,9 @@ when 'rhel', 'fedora'
   package 'openssl-devel'
 when 'debian', 'ubuntu'
   package 'libssl-dev'
+  if node['zeromq']['version'] =~ /^2\..*/
+    package 'uuid-dev'
+  end
 end
 
 zeromq_tar = "zeromq-#{node['zeromq']['version']}.tar.gz"


### PR DESCRIPTION
Hey,

i also have a second one.
If i try to install zeromq version 2.2.0 i get the exception that it cannot link against luuid. Some quick research told me to install uuid-dev before calling make. And this now works for me.
