### PR TITLE
required version of libsodium is now at an archive url

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,6 @@ default['zeromq']['src_url'] = 'https://github.com/zeromq/zeromq4-1.git'
 default['zeromq']['version'] = 'v4.1.4'
 default['zeromq']['creates'] = 'libzmq.so'
 default['zeromq']['libsodium_version'] = '1.0.10'
-default['zeromq']['libsodium_src_url'] = 'https://download.libsodium.org/libsodium/releases/libsodium-1.0.10.tar.gz'
+default['zeromq']['libsodium_src_url'] = 'https://download.libsodium.org/libsodium/releases/old/libsodium-1.0.10.tar.gz'
 default['zeromq']['libsodium_sha256_sum'] = '71b786a96dd03693672b0ca3eb77f4fb08430df307051c0d45df5353d22bc4be'
 default['zeromq']['install_libsodium'] = true


### PR DESCRIPTION
unless this is changed (or overridden in another cookbooks attributes) this recipe will fail with a 404. The 1.0.10 source tar is now in at a different url.